### PR TITLE
Support projection with batchGetItem operation

### DIFF
--- a/expression.go
+++ b/expression.go
@@ -134,3 +134,21 @@ func (i *Item) getConditionalUpdateExpression() (*expression.Expression, error) 
 	}
 	return &expr, nil
 }
+
+func (i *Item) batchGetItemExpression() (*expression.Expression, error) {
+	builder := expression.NewBuilder()
+	var expr expression.Expression
+	if i.projection != "" {
+		proj, err := projection(i.projection)
+		if err != nil {
+			return nil, err
+		}
+		builder = builder.WithProjection(*proj)
+
+		expr, err = builder.Build()
+		if err != nil {
+			log.Fatalf("failed to build expression, %v", err)
+		}
+	}
+	return &expr, nil
+}


### PR DESCRIPTION
## What
Added support for Projection with `BatchGetItem` operation.

## Why
It is useful to fetch selected fields from table.

## Limitation
The project attributes should be same for all `AddBatchGetItem`.
Error in case of different project attributes would be handled in separate PR.

```
for _, gId := range gIds {
    db.PK(gId).SK(Equal(SK)).Project("_partition_key", "_entity_type", "_sort_key", "logical_name").AddBatchGetItem(item, true)
}
```